### PR TITLE
Allow overriding InfoWindow view

### DIFF
--- a/app/templates/components/google-map.hbs
+++ b/app/templates/components/google-map.hbs
@@ -4,7 +4,7 @@
     {{#each marker in _markers itemViewClass=markerViewClass}}
       <li>{{marker.title}} @ {{marker.lat}},{{marker.lng}}</li>
       {{#if view.hasInfoWindow}}
-        {{view 'google-map/info-window' context=marker}}
+        {{view view.infoWindowViewClass context=marker}}
       {{/if}}
     {{/each}}
   </ul>

--- a/app/views/google-map/marker.js
+++ b/app/views/google-map/marker.js
@@ -47,6 +47,10 @@ export default GoogleMapCoreView.extend({
     return this.get('controller.infoWindowTemplateName') || this.get('parentView.markerInfoWindowTemplateName');
   }).readOnly(),
 
+  infoWindowViewClass: computed('controller.infoWindowViewClass', 'parentView.infoWindowViewClass', function () {
+    return this.get('controller.infoWindowViewClass') || this.get('parentView.infoWindowViewClass');
+  }).readOnly(),
+
   infoWindowAnchor: oneWay('googleObject'),
 
   isInfoWindowVisible: alias('controller.isInfoWindowVisible'),


### PR DESCRIPTION
This allows a marker' view overriding its `infoWindow` class.