### PR TITLE
Add missing reference to geodesic boolean for polylines

### DIFF
--- a/app/views/google-map/polyline.js
+++ b/app/views/google-map/polyline.js
@@ -40,6 +40,7 @@ export default GoogleMapCoreView.extend({
   isDraggable:      alias('controller.isDraggable'),
   isClickable:      alias('controller.isClickable'),
   isEditable:       alias('controller.isEditable'),
+  isGeodesic:       alias('controller.isGeodesic'),
   icons:            alias('controller.icons'),
 
   initGoogleObject: on('didInsertElement', function () {


### PR DESCRIPTION
This appears to be missing from `polylines.js` and so geodesic Polylines don't work without it. 