### PR TITLE
[FIX] Create alias for title & description

### DIFF
--- a/app/controllers/google-map/info-window.js
+++ b/app/controllers/google-map/info-window.js
@@ -12,5 +12,7 @@ export default Ember.Controller.extend({
   zIndex:       alias('model.zIndex'),
   lat:          alias('model.lat'),
   lng:          alias('model.lng'),
-  isVisible:    alias('model.isVisible')
+  isVisible:    alias('model.isVisible'),
+  title:        alias('model.title'),
+  description:  alias('model.description')
 });


### PR DESCRIPTION
As per the documentation for the deprecation of object controllers,
model properties must now be referenced explicitly via the model as
proxying behaviour has been removed:
http://emberjs.com/deprecations/v1.x/#toc_objectcontroller