### PR TITLE
Changed info-window View controller context to context property

### DIFF
--- a/app/views/google-map/info-window.js
+++ b/app/views/google-map/info-window.js
@@ -43,6 +43,7 @@ export default GoogleMapCoreView.extend({
   _coreGoogleEvents: ['closeclick'],
 
   // aliased from controller so that if they are not defined they use the values from the controller
+  controller: alias('context'),
   zIndex: alias('controller.zIndex'),
   lat:    alias('controller.lat'),
   lng:    alias('controller.lng'),


### PR DESCRIPTION
Found that the info-window View's `controller` and `parentView` properties were referencing the google-map component itself.  Since we are now iterating without using `itemViewClass` and instead setting the context on the info-windows this PR changes the `controller` prop to proxy the `context`.  It's a bit hackish, however does make it more apparent that the context references properties set via itemController.

This PR does not correct issues with marker info-windows, which also seem to have some context issues.