### PR TITLE
[FIX] beforeObserver -> observer

### DIFF
--- a/addon/mixins/google-object.js
+++ b/addon/mixins/google-object.js
@@ -251,7 +251,7 @@ var GoogleObjectMixin = Ember.Mixin.create({
   /**
    * Unlink the google object
    */
-  unlinkGoogleObject: Ember.beforeObserver('googleObject', function () {
+  unlinkGoogleObject: Ember.observer('googleObject', function () {
     this.get('_compiledEvents').invoke('unlink');
     this.get('_compiledProperties').invoke('unlink');
   }),


### PR DESCRIPTION
beforeObserver is deprecated. See the following link for details:
http://emberjs.com/deprecations/v1.x/#toc_beforeobserver

As the old value is not used in this case, I simply assumed that it can just be an `observer` instead of a `beforeObserver`. If this is not the case then please feel free to close this PR.