### PR TITLE
[FIX] Fixed `fitBoundsArray` computed property.

### DIFF
--- a/app/components/google-map.js
+++ b/app/components/google-map.js
@@ -185,6 +185,7 @@ export default Ember.Component.extend(GoogleObjectMixin, {
       },
       set(key, value) {
         this._fixedFitBoundsArray = value;
+        return value;
       }
     }
   ),


### PR DESCRIPTION
This fixes a bug that causes `fitBoundsArray` not to work.

I have tested `autoFitBounds=true` to ensure that this still works with this change.