### PR TITLE
Fix issue where map events aren't firing

### DIFF
--- a/addon/mixins/google-object.js
+++ b/addon/mixins/google-object.js
@@ -188,16 +188,16 @@ var GoogleObjectMixin = Ember.Mixin.create({
       }
 
       // finally add all overwritten events (`ev_xyz` properties)
-      forEach(Object.keys(this), function (key) {
-        var d, matches, action;
+      for(var key in this.get('attrs')) {
+        var c, matches, action;
         if ((matches = key.match(/^ev_(.+)$/)) && (action = this.get(key))) {
-          d = {action: this.get(key)};
+          c = {action: this.get(key)};
           if (defaultTarget) {
-            d.target = defaultTarget;
+            c.target = defaultTarget;
           }
-          res.push(new GoogleObjectEvent(matches[1], d));
+          res.push(new GoogleObjectEvent(matches[1], c));
         }
-      }, this);
+      }
 
       return Ember.A(res);
     }

--- a/addon/mixins/google-object.js
+++ b/addon/mixins/google-object.js
@@ -155,7 +155,8 @@ var GoogleObjectMixin = Ember.Mixin.create({
    */
   _compiledEvents: computed({
     get () {
-      var def, k, res, d, defaultTarget;
+      var attrs, attr, def, k, res, d, defaultTarget;
+      attrs = this.get('attrs');
       def = this.get('googleEvents') || {};
       res = [];
       defaultTarget = this.get('googleEventsTarget');
@@ -188,10 +189,10 @@ var GoogleObjectMixin = Ember.Mixin.create({
       }
 
       // finally add all overwritten events (`ev_xyz` properties)
-      for(var key in this.get('attrs')) {
+      for (attr in attrs) {
         var c, matches, action;
-        if ((matches = key.match(/^ev_(.+)$/)) && (action = this.get(key))) {
-          c = {action: this.get(key)};
+        if ((matches = attr.match(/^ev_(.+)$/)) && (action = this.get(attr))) {
+          c = {action: this.get(attr)};
           if (defaultTarget) {
             c.target = defaultTarget;
           }

--- a/app/components/google-map.js
+++ b/app/components/google-map.js
@@ -127,9 +127,7 @@ export default Ember.Component.extend(GoogleObjectMixin, {
   /**
    * @inheritDoc
    */
-  googleEvents: {
-    click: 'click'
-  },
+  googleEvents: {},
 
 
   /**

--- a/app/components/google-map.js
+++ b/app/components/google-map.js
@@ -127,7 +127,9 @@ export default Ember.Component.extend(GoogleObjectMixin, {
   /**
    * @inheritDoc
    */
-  googleEvents: {},
+  googleEvents: {
+    click: 'click'
+  },
 
 
   /**


### PR DESCRIPTION
Seems like the issue was with Object.keys() not returning all of the object's properties