### PR TITLE
[MISC] Add support for channel param when loading maps.

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,6 +29,10 @@ module.exports = {
       if (google.libraries && google.libraries.length) {
         params.push('libraries=' + encodeURIComponent(google.libraries.join(',')));
       }
+      // add channel param if specified
+      if (google.channel) {
+        params.push('channel=' + encodeURIComponent(google.channel));
+      }
       // build our URL
       src += '?' + params.join('&');
       if (google.lazyLoad) {


### PR DESCRIPTION
This adds support for the `channel` config option, which is helpful for tracking multiple apps that use the same Maps for Work licence:

https://developers.google.com/maps/documentation/business/clientside/load#channel_reporting