### PR TITLE
Prevent deprecation for initializer

### DIFF
--- a/app/initializers/ember-google-map.js
+++ b/app/initializers/ember-google-map.js
@@ -1,6 +1,6 @@
 import loadGoogleMap from 'ember-google-map/utils/load-google-map';
 
-export function initialize(container, application) {
+export function initialize(application) {
   application.register('util:load-google-map', loadGoogleMap, {instantiate: false});
   application.inject('route', 'loadGoogleMap', 'util:load-google-map');
 }


### PR DESCRIPTION
Was previously getting a deprecation warning in the console for including container in the initializer.  
See this portion of the ember deprecation docs for more details: http://emberjs.com/deprecations/v2.x/#toc_initializer-arity
